### PR TITLE
fix: escape Jekyll liquid syntax in random process notes

### DIFF
--- a/研究生课程(学硕版)/应用随机过程/一纸开卷.md
+++ b/研究生课程(学硕版)/应用随机过程/一纸开卷.md
@@ -345,7 +345,7 @@ $=\left.\frac{a}{2 \pi} \sin \left(\omega_{0} t+\varphi\right)\right|_{0} ^{2 \p
 $=E\left[{a^2}\cos(\omega_0t_1+\Phi)\cos(\omega_0t_2+\Phi)\right]$
 $
 ={a}^2\int_0^{2\pi}\cos(\omega_0t_1+\phi)\cos(\omega_0t_2+\phi)\cdot\frac{1}{2\pi}d\phi$
-$=\frac{{a}^2}{2\pi}\cdot\frac{1}{2}\int_0^{2\pi}\left[\cos(\omega_0(t_1+t_2)+2\phi)+\cos\omega_0(t_1-t_2)\right]d\phi$
+$=\frac{a^2}{2\pi}\cdot\frac{1}{2}\int_0^{2\pi}\left[\cos(\omega_0(t_1+t_2)+2\phi)+\cos\omega_0(t_1-t_2)\right]d\phi$
 $=\frac{a^2}{4\pi}\left[\frac{1}{2}\sin(\omega_0(t_1+t_2)+2\varphi)|_{0} ^{2 \pi}+2\pi\cos\omega_0(t_1-t_2)\right]$
 $
 =\frac{a^2}{2}\cos\omega_0(t_1-t_2)$
@@ -590,7 +590,7 @@ $\large \mathcal{F}^{-1} \left[\frac{\frac{3}{8}}{w^2+1}\right] = \mathcal{F}^{-
 
 **21.**$$R_X(\tau)=e^{-a|\tau|}\cos\omega_0\tau\text{,其中 }a>0$$，求功率谱密度
 $\mathscr{F}\left[ {f\left( \tau \right)\cos \omega _0 \tau } \right]= \int_{ - \infty }^{ + \infty } {f\left( \tau \right)\cos \omega _0 \tau \cdot e^{ - i\omega \tau } d\tau }$
-$= \int_{ - \infty }^{ + \infty }\large {f\left( \tau \right)\frac{{{e^{i\omega _0 \tau }} + {e^{ - i\omega _0 \tau }}}}{{2}} \cdot e^{ - i\omega \tau } d\tau }$
+$= \int_{ - \infty }^{ + \infty }\large {f\left( \tau \right)\frac{e^{i\omega _0 \tau } + e^{ - i\omega _0 \tau }}{2} \cdot e^{ - i\omega \tau } d\tau }$
 $= \frac{1}{2}( \int_{ - \infty }^{ + \infty } {f\left( \tau \right) \cdot {e^{ - i\left( {\omega - \omega _0 } \right)\tau }}d\tau } + \int_{ - \infty }^{ + \infty } {f\left( \tau \right) \cdot {e^{-i\left( {\omega + \omega _0 } \right)\tau }}d\tau })$
 $= \frac{1}{2}\left( {F\left( {\omega - \omega _0 } \right) + F\left( {\omega + \omega _0 } \right)} \right)$
 $\int_{-\infty}^{+\infty}f(\tau)e^{-i\omega\tau}d\tau=\mathscr{F}[f(\tau)] = F(\omega)，\mathscr{F}[e^{-a|\tau|}]=\frac{2a}{a^2 + \omega^2}$


### PR DESCRIPTION
## Summary

- fix LaTeX brace sequences in `研究生课程(学硕版)/应用随机过程/一纸开卷.md` that GitHub Pages/Jekyll interpreted as Liquid template delimiters
- preserve the mathematical meaning while avoiding `{{ ... }}` syntax in Markdown

## Verification

- `ruby -e 'require "liquid"; Liquid::Template.parse(File.read(ARGV[0])); puts "liquid parse ok"' 研究生课程(学硕版)/应用随机过程/一纸开卷.md`
- `rg -n '\{\{|\{%|%\}' 研究生课程(学硕版)/应用随机过程/一纸开卷.md`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced mathematical formula presentation in course materials through improved LaTeX notation formatting for better readability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HITLittleZheng/HITCS/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->